### PR TITLE
chore: update SDK version to latest (2.0.6) in build.gradle.kts

### DIFF
--- a/samplekotlin/build.gradle.kts
+++ b/samplekotlin/build.gradle.kts
@@ -70,7 +70,7 @@ android {
 }
 
 dependencies {
-    implementation("io.axept.android:android-sdk:2.0.5")
+    implementation("io.axept.android:android-sdk:2.0.6")
 
     implementation(platform("com.google.firebase:firebase-bom:32.7.2"))
     implementation("com.google.firebase:firebase-analytics")


### PR DESCRIPTION
Updated SDK version so the app uses the latest (2.0.6) which include some fixes. 