### PR TITLE
docs: clean up README documentation and fix inaccuracies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 1.0.0-beta.1 (2025-08-29)
+
+
+### Features
+
+* add comprehensive automation scripts for Android sample app testing ([1544738](https://github.com/axeptio/sample-app-android/commit/15447382323ddc8e4dcb0cbc518176dd5c2b8885))
+* add SDK version display to main screen header ([57b2b9f](https://github.com/axeptio/sample-app-android/commit/57b2b9f0791252e8229a13624f30cd0a9f831c13))
+* **build:** add comprehensive quality gates and security scanning to ci pipeline ([d6f2361](https://github.com/axeptio/sample-app-android/commit/d6f23616213f82ae4a80af40358303c8626dbd6e))
+* complete sdk implementation instructions ([a99cfe9](https://github.com/axeptio/sample-app-android/commit/a99cfe98a00783b5f990535acfeebee0520bc949))
+* enhance debug capabilities and fix configuration management ([5896441](https://github.com/axeptio/sample-app-android/commit/589644129c0247a315744d1159f9cfb8962af652))
+* implement comprehensive TCF vendor consent testing capabilities ([03846b8](https://github.com/axeptio/sample-app-android/commit/03846b84571ef951674fe8acd8daebf8bf58cd9a))
+* readme instructions ([ba95cdd](https://github.com/axeptio/sample-app-android/commit/ba95cddf24881241b841582e6d2aaa0cf0135f31))
+* **release:** implement comprehensive semantic versioning and automated releases ([09be413](https://github.com/axeptio/sample-app-android/commit/09be4136bafe19f8c406bef6c559c368d46c657c))
+
+
+### Bug Fixes
+
+* Add more detail on documentation ([36adaa9](https://github.com/axeptio/sample-app-android/commit/36adaa9a9313df5f9ec9716dec0edbb6eb38b87e))
+* Add more detail on documentation ([e118e5b](https://github.com/axeptio/sample-app-android/commit/e118e5b35ff702f02dbe8f63153de6776ea969c5))
+* **build:** disable subject case validation in commitlint ([5145cea](https://github.com/axeptio/sample-app-android/commit/5145cea4020f31beabfc5655bd75bef010da900e))
+* **build:** remove failing OWASP security scan and create MSK-85 for gradle upgrade ([e0d9171](https://github.com/axeptio/sample-app-android/commit/e0d917109e86664955a36774dd00d2e4e2792d9d))
+* **build:** resolve compose preview compilation and commitlint validation issues ([eab0d15](https://github.com/axeptio/sample-app-android/commit/eab0d15bb0aa39b7a20d28243d631b204c220cdc))
+* **build:** resolve github actions workflow failures and pin node.js version ([4ea7b2a](https://github.com/axeptio/sample-app-android/commit/4ea7b2ac06274cf42dac30e907efed52e278d786))
+* **build:** use published sdk 2.0.8 for ci builds and make local sdk optional ([795e903](https://github.com/axeptio/sample-app-android/commit/795e9037a1e57e952bd892b71676bf7ad03e7f82))
+* update README ([bade8a4](https://github.com/axeptio/sample-app-android/commit/bade8a4414e30ce97c616003b1f21696e2ace959))
+* update README ([19efdd3](https://github.com/axeptio/sample-app-android/commit/19efdd3327e0e854e119eb5a8908d81568640d13))
+* use secrets ([96322dd](https://github.com/axeptio/sample-app-android/commit/96322ddb636ac19c0e4455f6c90b1571ead83fde))
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 
 Welcome to the Axeptio Mobile SDK Samples project! This repository demonstrates how to implement the **Axeptio Android SDK** in your mobile applications.
-## 📑 Table of Contents
+## Table of Contents
 1. [Overview](#overview)
 2. [Getting Started](#getting-started)
 3. [Local Testing with Production Widget Configuration](#local-testing-with-production-widget-configuration)
@@ -30,7 +30,7 @@ Welcome to the Axeptio Mobile SDK Samples project! This repository demonstrates 
 
 <br><br>
 
-## 👨‍💻Overview
+## Overview
 This project includes two modules:
 - `samplejava`: Demonstrates how to use the Axeptio SDK with Java and XML.
 - `samplekotlin`: Shows the integration of the Axeptio SDK with Kotlin and Compose, including advanced debugging features and configuration management.
@@ -63,7 +63,7 @@ git clone https://github.com/axeptio/sample-app-android
 > The following steps explain how to create a Personal Access Token and configure Gradle to use it securely via environment variables.
 
 To properly configure access to the Axeptio SDK, you need to add your GitHub token in the `settings.gradle.kts` file to fetch the SDK from the private repository. The library is not available on a public Maven repository, so it is crucial to configure the private repository correctly to avoid errors. You can also consider publishing the Axeptio SDK to a public repository to simplify integration, reducing the process complexity. Here’s how to configure the private repository in the `settings.gradle.kts` file:
-```kotin
+```kotlin
 maven {
     url = uri("https://maven.pkg.github.com/axeptio/axeptio-android-sdk")
     credentials {
@@ -143,7 +143,7 @@ To test the version currently in production, instead checkout the `sample-app-an
 implementation("io.axept.android:android-sdk:2.0.6")
 ```
 To configure the widget, update the productFlavors in `build.gradle.kts` with the appropriate `AXEPTIO_CLIENT_ID`, `AXEPTIO_COOKIES_VERSION`, and `AXEPTIO_TARGET_SERVICE`. Example:
-```kotin
+```kotlin
 productFlavors {
     create("publishers") {
         dimension = "service"
@@ -160,9 +160,9 @@ productFlavors {
 }
 ```
 Use the *Build Variants* tab to switch between brands and publishers as needed. Finally, make sure your `settings.gradle.kts` includes your GitHub credentials for accessing the SDK:
-```kotin
+```kotlin
 maven {
-    url = uri("https://maven.pkg.github.com/axeptio/tcf-android-sdk")
+    url = uri("https://maven.pkg.github.com/axeptio/axeptio-android-sdk")
     credentials {
         username = "USER" // TODO: GITHUB USERNAME
         password = "TOKEN" // TODO: GITHUB TOKEN
@@ -171,7 +171,7 @@ maven {
 ```
 
 <br><br><br>
-## 🔀Switching Between Publisher and Brand Flavors
+## Switching Between Publisher and Brand Flavors
 The Axeptio SDK provides two build flavors: `publishers` and `brands`. You can switch between them depending on your project needs. Each flavor activates specific behavior in the SDK.
 #### In Android Studio:
 1. Locate the *"Build Variants"* tab (usually in the lower-left corner of the IDE).
@@ -193,7 +193,7 @@ Make sure to clean the project if you switch flavors often:
 
 
 <br><br><br>
-## 💻Axeptio SDK Implementation
+## Axeptio SDK Implementation
 The Axeptio SDK provides consent management functionality for Android applications, enabling seamless integration for handling user consent.
 
 ##### Gradle Implementation
@@ -301,33 +301,6 @@ Once the SDK is initialized, the consent popup will automatically display if the
 ##### Transferring User Consents (Publishers)
 For publishers, you can transfer a user's consent information by providing their Axeptio token. This token allows the SDK to automatically update the user's consent preferences in the SharedPreferences, following the TCFv2 (Transparency and Consent Framework) IAB (Interactive Advertising Bureau) specifications.
 
-##### Preventing Multiple Initializations of the SDK
-Calling `initialize()` multiple times during the same session can cause crashes. To avoid this, always check if the SDK has already been initialized before making the call:
-- **Kotlin**
-```kotlin
-if (!AxeptioSDK.instance().isInitialized()) {
-    AxeptioSDK.instance().initialize(
-        activity = this@MainActivity,
-        targetService = AxeptioService.PUBLISHERS_TCF,
-        clientId = "your_client_id",
-        cookiesVersion = "your_cookies_version",
-        token = "optional_consent_token"
-    )
-}
-```
-- **Java**
-```java
-if (!AxeptioSDK.instance().isInitialized()) {
-    AxeptioSDK.instance().initialize(
-        MainActivity.this,
-        AxeptioService.PUBLISHERS_TCF,
-        "your_project_id",
-        "your_configuration_id",
-        "optional_consent_token"
-    );
-}
-```
-By checking the `isInitialized()` method, you ensure that the SDK is initialized only once, preventing potential issues caused by multiple initializations.
 
 ##### Handling the "INSTALL_FAILED_INVALID_APK" Error
 This error can occur during installation, typically due to issues with the APK or dependencies. The best solution is to perform a **clean build** to ensure that all libraries are properly integrated. To do so, execute the following command in your terminal:
@@ -362,7 +335,7 @@ The integration of the Axeptio SDK into your mobile application involves clear d
 
 <br><br><br>
 
-## 🔑Get Stored Consents
+## Get Stored Consents
 You can retrieve the consents stored by the Axeptio SDK in **SharedPreferences**. The following example demonstrates how to access these values within your app:
 - **Kotlin Examples**
 ```kotlin
@@ -386,7 +359,7 @@ AxeptioSDK.instance().showConsentScreen(
     managePreferencesUseCase = true  // Optional: Manages user preferences when the popup is shown
 )
 ```
--**Java**
+- **Java**
 ```java
 // Show the consent popup on demand
 AxeptioSDK.instance().showConsentScreen(
@@ -406,7 +379,7 @@ AxeptioSDK.instance().setEventListener(object : AxeptioEventListener {
     }
 })
 ```
--**Java**
+- **Java**
 ```java
 // Set an event listener for when the consent popup is closed
 AxeptioSDK.instance().setEventListener(new AxeptioEventListener() {
@@ -448,7 +421,7 @@ AxeptioSDK.instance().appendAxeptioToken(
 This will return: `https://myurl.com?axeptio_token=[token]`
 
 <br><br><br>
-## 🧹Clear User's Consent Choices
+## Clear User's Consent Choices
 To clear the user’s consent choices, you can use the following method. Please note that this operation is asynchronous, so you should use the `AxeptioEventListener.onConsentCleared()` method to be notified when the user’s consent choices have been cleared from SharedPreferences.
 - **Kotlin**
 ```kotlin
@@ -562,7 +535,7 @@ By following these steps, you can ensure that Google Consent Mode is correctly i
 
 <br><br><br>
 
-## 🔬 Advanced SDK APIs - Vendor Consent Management
+## Advanced SDK APIs - Vendor Consent Management
 The Axeptio SDK provides advanced APIs for detailed vendor consent analysis and management. These APIs are particularly useful for Publishers using the TCF service to analyze and work with vendor-specific consent data.
 
 ### Vendor Consent Query APIs
@@ -689,15 +662,7 @@ fun processUserData(vendorId: Int, userData: UserData) {
 }
 ```
 
-5. **Initialization Check**: Ensure the SDK is initialized before calling these APIs:
-```kotlin
-if (AxeptioSDK.instance().isInitialized()) {
-    val consents = AxeptioSDK.instance().getVendorConsents()
-    // Process consents...
-} else {
-    Log.w("SDK", "AxeptioSDK not initialized - cannot retrieve vendor consents")
-}
-```
+5. **Initialization Check**: Ensure the SDK is initialized before calling these APIs by checking that you have called the `initialize()` method successfully before attempting to retrieve vendor consent data.
 
 > **⚠️ Important Note**: The vendor consent APIs are available starting from SDK version 2.1.0 and are primarily intended for Publishers using the TCF service. For Brands service implementations, these APIs may return empty or limited data.
 

--- a/samplejava/build.gradle.kts
+++ b/samplejava/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.davinciapp.samplejava"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = NaN
+        versionName = "1.0.0-beta.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/samplekotlin/build.gradle.kts
+++ b/samplekotlin/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "io.axept.samplekotlin"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = NaN
+        versionName = "1.0.0-beta.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- Remove emoji icons from section headings for professional appearance
- Fix Table of Contents consistency with actual section titles
- Remove references to non-existent `isInitialized()` method  
- Update deprecated repository URL from `tcf-android-sdk` to `axeptio-android-sdk`
- Fix typos: "kotin" → "kotlin" and spacing issues
- Preserve accurate vendor consent APIs documentation (confirmed in PR #38, #39)

## Test plan
- [x] Cross-checked implementation against actual SDK sources
- [x] Verified vendor consent APIs exist in `feat/msk-82-vendor-consent-parsing` branch
- [x] Confirmed repository URL corrections match current SDK distribution
- [x] Validated all code examples for syntax correctness

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Cleaned up README for accuracy and clarity: removed emojis from headings, fixed the Table of Contents, corrected Kotlin code fences, updated the private repo URL, and removed the non-existent isInitialized() reference. Added the 1.0.0-beta.1 entry to the changelog and updated the sample apps’ versionName to 1.0.0-beta.1; kept vendor consent API docs and clarified initialization guidance.

<!-- End of auto-generated description by cubic. -->

