### PR TITLE
fix: MSK-86/fix-deprecated-api-warnings-in-android-sample-app

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,40 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
+          <package name="android" withSubpackages="true" static="true" />
+          <package name="androidx" withSubpackages="true" static="true" />
+          <package name="com" withSubpackages="true" static="true" />
+          <package name="junit" withSubpackages="true" static="true" />
+          <package name="net" withSubpackages="true" static="true" />
+          <package name="org" withSubpackages="true" static="true" />
+          <package name="java" withSubpackages="true" static="true" />
+          <package name="javax" withSubpackages="true" static="true" />
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="android" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="androidx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="junit" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="net" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,9 +4,25 @@
     <selectionStates>
       <SelectionState runConfigName="samplejava">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-09-02T17:46:22.958241Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/mex_02/.android/avd/Pixel_8.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
       <SelectionState runConfigName="samplekotlin">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-09-02T17:47:15.222761Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/mex_02/.android/avd/Medium_Phone.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,10 +2,10 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="samplekotlin">
+      <SelectionState runConfigName="samplejava">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="samplejava">
+      <SelectionState runConfigName="samplekotlin">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../axeptio-android-sdk-sources" vcs="Git" />
   </component>
 </project>

--- a/samplejava/build.gradle.kts
+++ b/samplejava/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         applicationId = "com.davinciapp.samplejava"
         minSdk = 26
         targetSdk = 35
-        versionCode = NaN
+        versionCode = 1
         versionName = "1.0.0-beta.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/samplejava/src/main/java/com/davinciapp/samplejava/MainViewModel.java
+++ b/samplejava/src/main/java/com/davinciapp/samplejava/MainViewModel.java
@@ -10,9 +10,6 @@ import androidx.lifecycle.ViewModelProvider;
 
 import java.util.ArrayList;
 
-import io.axept.android.library.AxeptioService;
-import io.axept.android.model.AxeptioCookies;
-
 public class MainViewModel extends ViewModel {
 
     private SharedPreferencesRepository prefRepo;
@@ -63,8 +60,12 @@ public class MainViewModel extends ViewModel {
 
         @NonNull
         @Override
+        @SuppressWarnings("unchecked")
         public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-            return (T) new MainViewModel(new SharedPreferencesRepositoryImpl(app));
+            if (modelClass.isAssignableFrom(MainViewModel.class)) {
+                return (T) new MainViewModel(new SharedPreferencesRepositoryImpl(app));
+            }
+            throw new IllegalArgumentException("Unknown ViewModel class: " + modelClass);
         }
     }
 }

--- a/samplejava/src/main/java/com/davinciapp/samplejava/SharedPreferencesRepository.java
+++ b/samplejava/src/main/java/com/davinciapp/samplejava/SharedPreferencesRepository.java
@@ -1,6 +1,7 @@
 package com.davinciapp.samplejava;
 
 import android.app.Application;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
@@ -15,7 +16,10 @@ class SharedPreferencesRepositoryImpl implements SharedPreferencesRepository {
 
     SharedPreferencesRepositoryImpl(Application application) {
         this.application = application;
-        this.pref = PreferenceManager.getDefaultSharedPreferences(application);
+        this.pref = application.getSharedPreferences(
+                application.getPackageName() + "_preferences",
+                Context.MODE_PRIVATE
+        );
     }
 
     @Override
@@ -58,9 +62,9 @@ enum TCFFields {
     PublisherLegitimateInterests("IABTCF_PublisherLegitimateInterests", String.class),
     PublisherCustomPurposesConsents("IABTCF_PublisherCustomPurposesConsents", String.class),
     PublisherCustomPurposesLegitimateInterests(
-        "IABTCF_PublisherCustomPurposesLegitimateInterests",
-        String.class
-        );
+            "IABTCF_PublisherCustomPurposesLegitimateInterests",
+            String.class
+    );
 
     String key;
     Class<?> type;

--- a/samplejava/src/main/java/com/davinciapp/samplejava/WebViewActivity.java
+++ b/samplejava/src/main/java/com/davinciapp/samplejava/WebViewActivity.java
@@ -1,5 +1,6 @@
 package com.davinciapp.samplejava;
 
+import android.annotation.SuppressLint;
 import android.net.Uri;
 import android.os.Bundle;
 import android.webkit.WebView;
@@ -12,6 +13,7 @@ import io.axept.android.library.AxeptioSDK;
 
 public class WebViewActivity extends AppCompatActivity {
 
+    @SuppressLint("SetJavaScriptEnabled")
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/samplekotlin/build.gradle.kts
+++ b/samplekotlin/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         applicationId = "io.axept.samplekotlin"
         minSdk = 26
         targetSdk = 35
-        versionCode = NaN
+        versionCode = 1
         versionName = "1.0.0-beta.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/samplekotlin/src/main/java/io/axept/samplekotlin/screen/DebugConsentInfoScreen.kt
+++ b/samplekotlin/src/main/java/io/axept/samplekotlin/screen/DebugConsentInfoScreen.kt
@@ -1,24 +1,44 @@
 package io.axept.samplekotlin.screen
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
+import android.annotation.SuppressLint
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,6 +51,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 
+@SuppressLint("DefaultLocale")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DebugConsentInfoScreen(
@@ -49,7 +70,7 @@ fun DebugConsentInfoScreen(
                 title = { Text("Debug Consent Info") },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
                 actions = {
@@ -534,7 +555,6 @@ private fun CopyableDebugInfoItem(
     value: String
 ) {
     val clipboardManager = LocalClipboardManager.current
-    val context = LocalContext.current
     
     Column(
         modifier = Modifier

--- a/samplekotlin/src/main/java/io/axept/samplekotlin/screen/DebugConsentInfoScreen.kt
+++ b/samplekotlin/src/main/java/io/axept/samplekotlin/screen/DebugConsentInfoScreen.kt
@@ -50,8 +50,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import java.util.Locale
 
-@SuppressLint("DefaultLocale")
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DebugConsentInfoScreen(
@@ -63,7 +64,7 @@ fun DebugConsentInfoScreen(
     )
 ) {
     val debugInfo by viewModel.debugInfo.collectAsState()
-    
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -95,6 +96,7 @@ fun DebugConsentInfoScreen(
                         CircularProgressIndicator()
                     }
                 }
+
                 debugInfo.error != null -> {
                     Card(
                         modifier = Modifier
@@ -109,6 +111,7 @@ fun DebugConsentInfoScreen(
                         )
                     }
                 }
+
                 else -> {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
@@ -132,33 +135,53 @@ fun DebugConsentInfoScreen(
                                 initiallyExpanded = true
                             ) {
                                 debugInfo.consentInfo?.let { consentInfo ->
-                                    val hasAnyConsent = consentInfo.hasConsent || 
-                                                       consentInfo.rawDebugInfo.isNotEmpty() ||
-                                                       consentInfo.consentString.isNotBlank()
-                                    
+                                    val hasAnyConsent = consentInfo.hasConsent ||
+                                            consentInfo.rawDebugInfo.isNotEmpty() ||
+                                            consentInfo.consentString.isNotBlank()
+
                                     if (!hasAnyConsent) {
                                         DebugInfoItem("✅ State", "Clean - No consent data found")
-                                        DebugInfoItem("Ready for Testing", "You can now show consent popup for testing")
+                                        DebugInfoItem(
+                                            "Ready for Testing",
+                                            "You can now show consent popup for testing"
+                                        )
                                     } else {
-                                        DebugInfoItem("⚠️ State", "Consent data exists - not clean", isError = true)
-                                        DebugInfoItem("Action Needed", "Use 'Clear consent' button to reset", isError = true)
+                                        DebugInfoItem(
+                                            "⚠️ State",
+                                            "Consent data exists - not clean",
+                                            isError = true
+                                        )
+                                        DebugInfoItem(
+                                            "Action Needed",
+                                            "Use 'Clear consent' button to reset",
+                                            isError = true
+                                        )
                                     }
-                                    
+
                                     // Show quick state summary
                                     debugInfo.vendorInfo?.let { vendorInfo ->
-                                        DebugInfoItem("Vendor Count", "${vendorInfo.totalVendors} total, ${vendorInfo.consentedVendorsCount} consented")
+                                        DebugInfoItem(
+                                            "Vendor Count",
+                                            "${vendorInfo.totalVendors} total, ${vendorInfo.consentedVendorsCount} consented"
+                                        )
                                     }
-                                    
+
                                     val rawDataCount = consentInfo.rawDebugInfo.size
-                                    DebugInfoItem("Raw Debug Fields", "$rawDataCount IABTCF fields present")
-                                    
+                                    DebugInfoItem(
+                                        "Raw Debug Fields",
+                                        "$rawDataCount IABTCF fields present"
+                                    )
+
                                     if (consentInfo.consentString.isNotBlank() && consentInfo.consentString != "No TCF string available") {
-                                        DebugInfoItem("TCF String Status", "Present (${consentInfo.consentString.length} chars)")
+                                        DebugInfoItem(
+                                            "TCF String Status",
+                                            "Present (${consentInfo.consentString.length} chars)"
+                                        )
                                     } else {
                                         DebugInfoItem("TCF String Status", "Empty/Not found")
                                     }
                                 }
-                                
+
                                 // Clear Consent Instructions
                                 Text(
                                     text = "🔄 Testing Workflow",
@@ -167,9 +190,18 @@ fun DebugConsentInfoScreen(
                                     modifier = Modifier.padding(vertical = 8.dp)
                                 )
                                 DebugInfoItem("1. Clear", "Tap 'Clear consent' on main screen")
-                                DebugInfoItem("2. Refresh", "Tap refresh button above to verify clean state")
-                                DebugInfoItem("3. Test", "Show consent popup and try 'Accept All' vs manual selection")
-                                DebugInfoItem("4. Compare", "Use this debug screen to compare results")
+                                DebugInfoItem(
+                                    "2. Refresh",
+                                    "Tap refresh button above to verify clean state"
+                                )
+                                DebugInfoItem(
+                                    "3. Test",
+                                    "Show consent popup and try 'Accept All' vs manual selection"
+                                )
+                                DebugInfoItem(
+                                    "4. Compare",
+                                    "Use this debug screen to compare results"
+                                )
                             }
                         }
 
@@ -184,7 +216,10 @@ fun DebugConsentInfoScreen(
                                     DebugInfoItem("Client ID", sdkInfo.clientId)
                                     DebugInfoItem("Cookies Version", sdkInfo.cookiesVersion)
                                     DebugInfoItem("Target Service", sdkInfo.targetService)
-                                    DebugInfoItem("Is Initialized", if (sdkInfo.isInitialized) "✅ Yes" else "❌ No")
+                                    DebugInfoItem(
+                                        "Is Initialized",
+                                        if (sdkInfo.isInitialized) "✅ Yes" else "❌ No"
+                                    )
                                 }
                             }
                         }
@@ -198,7 +233,10 @@ fun DebugConsentInfoScreen(
                                 ) {
                                     DebugInfoItem("Current Service", configInfo.currentService)
                                     DebugInfoItem("Service Name", configInfo.serviceName)
-                                    DebugInfoItem("Available Configs", configInfo.availableConfigurations.joinToString(", "))
+                                    DebugInfoItem(
+                                        "Available Configs",
+                                        configInfo.availableConfigurations.joinToString(", ")
+                                    )
                                 }
                             }
                         }
@@ -210,14 +248,20 @@ fun DebugConsentInfoScreen(
                                     title = "Consent Information",
                                     initiallyExpanded = true
                                 ) {
-                                    DebugInfoItem("Has Consent", if (consentInfo.hasConsent) "✅ Yes" else "❌ No")
+                                    DebugInfoItem(
+                                        "Has Consent",
+                                        if (consentInfo.hasConsent) "✅ Yes" else "❌ No"
+                                    )
                                     DebugInfoItem("Last Updated", consentInfo.lastUpdated)
-                                    
+
                                     if (consentInfo.error != null) {
                                         DebugInfoItem("Error", consentInfo.error, isError = true)
                                     }
-                                    
-                                    CopyableDebugInfoItem("TCF Consent String", consentInfo.consentString)
+
+                                    CopyableDebugInfoItem(
+                                        "TCF Consent String",
+                                        consentInfo.consentString
+                                    )
                                 }
                             }
                         }
@@ -225,8 +269,9 @@ fun DebugConsentInfoScreen(
                         // TCF Bit String Analysis Section
                         debugInfo.consentInfo?.rawDebugInfo?.let { rawInfo ->
                             val vendorConsentsString = rawInfo["IABTCF_VendorConsents"] as? String
-                            val vendorLegitimateInterestsString = rawInfo["IABTCF_VendorLegitimateInterests"] as? String
-                            
+                            val vendorLegitimateInterestsString =
+                                rawInfo["IABTCF_VendorLegitimateInterests"] as? String
+
                             if (!vendorConsentsString.isNullOrEmpty() || !vendorLegitimateInterestsString.isNullOrEmpty()) {
                                 item {
                                     ExpandableDebugSection(
@@ -239,10 +284,16 @@ fun DebugConsentInfoScreen(
                                             fontWeight = FontWeight.Bold,
                                             modifier = Modifier.padding(vertical = 8.dp)
                                         )
-                                        
-                                        DebugInfoItem("Explanation", "Each character represents a vendor ID (position 0 = vendor 1)")
-                                        DebugInfoItem("'1' = Consented", "'0' = Refused or Not Available")
-                                        
+
+                                        DebugInfoItem(
+                                            "Explanation",
+                                            "Each character represents a vendor ID (position 0 = vendor 1)"
+                                        )
+                                        DebugInfoItem(
+                                            "'1' = Consented",
+                                            "'0' = Refused or Not Available"
+                                        )
+
                                         // Vendor Consents Analysis
                                         vendorConsentsString?.let { consentString ->
                                             Text(
@@ -251,37 +302,64 @@ fun DebugConsentInfoScreen(
                                                 fontWeight = FontWeight.Bold,
                                                 modifier = Modifier.padding(vertical = 8.dp)
                                             )
-                                            
+
                                             val totalLength = consentString.length
                                             val consentedCount = consentString.count { it == '1' }
                                             val refusedCount = consentString.count { it == '0' }
-                                            val invalidCount = totalLength - consentedCount - refusedCount
-                                            
-                                            DebugInfoItem("String Length", "$totalLength characters")
-                                            DebugInfoItem("Consented ('1')", "$consentedCount vendors")
-                                            DebugInfoItem("Refused ('0')", "$refusedCount vendors") 
+                                            val invalidCount =
+                                                totalLength - consentedCount - refusedCount
+
+                                            DebugInfoItem(
+                                                "String Length",
+                                                "$totalLength characters"
+                                            )
+                                            DebugInfoItem(
+                                                "Consented ('1')",
+                                                "$consentedCount vendors"
+                                            )
+                                            DebugInfoItem("Refused ('0')", "$refusedCount vendors")
                                             if (invalidCount > 0) {
-                                                DebugInfoItem("Invalid chars", "$invalidCount characters", isError = true)
+                                                DebugInfoItem(
+                                                    "Invalid chars",
+                                                    "$invalidCount characters",
+                                                    isError = true
+                                                )
                                             }
-                                            
+
                                             val consentPercentage = if (totalLength > 0) {
-                                                String.format("%.2f%%", (consentedCount.toDouble() / totalLength) * 100)
+                                                String.format(
+                                                    Locale.getDefault(),
+                                                    "%.2f%%",
+                                                    (consentedCount.toDouble() / totalLength) * 100,
+                                                )
                                             } else "0%"
-                                            DebugInfoItem("Consent Rate", "$consentPercentage of possible vendors")
-                                            
+                                            DebugInfoItem(
+                                                "Consent Rate",
+                                                "$consentPercentage of possible vendors"
+                                            )
+
                                             // Show pattern of first/last 20 characters
                                             if (consentString.length >= 20) {
                                                 val firstChars = consentString.take(20)
                                                 val lastChars = consentString.takeLast(20)
-                                                DebugInfoItem("First 20 chars", "\"$firstChars\" (vendors 1-20)")
+                                                DebugInfoItem(
+                                                    "First 20 chars",
+                                                    "\"$firstChars\" (vendors 1-20)"
+                                                )
                                                 if (consentString.length > 20) {
-                                                    DebugInfoItem("Last 20 chars", "\"$lastChars\" (vendors ${totalLength-19}-$totalLength)")
+                                                    DebugInfoItem(
+                                                        "Last 20 chars",
+                                                        "\"$lastChars\" (vendors ${totalLength - 19}-$totalLength)"
+                                                    )
                                                 }
                                             }
-                                            
-                                            CopyableDebugInfoItem("Full VendorConsents String", consentString)
+
+                                            CopyableDebugInfoItem(
+                                                "Full VendorConsents String",
+                                                consentString
+                                            )
                                         }
-                                        
+
                                         // Vendor Legitimate Interests Analysis
                                         vendorLegitimateInterestsString?.let { legitString ->
                                             Text(
@@ -290,23 +368,39 @@ fun DebugConsentInfoScreen(
                                                 fontWeight = FontWeight.Bold,
                                                 modifier = Modifier.padding(vertical = 8.dp)
                                             )
-                                            
+
                                             val totalLength = legitString.length
                                             val acceptedCount = legitString.count { it == '1' }
                                             val refusedCount = legitString.count { it == '0' }
-                                            
-                                            DebugInfoItem("String Length", "$totalLength characters")
-                                            DebugInfoItem("Accepted ('1')", "$acceptedCount vendors")
+
+                                            DebugInfoItem(
+                                                "String Length",
+                                                "$totalLength characters"
+                                            )
+                                            DebugInfoItem(
+                                                "Accepted ('1')",
+                                                "$acceptedCount vendors"
+                                            )
                                             DebugInfoItem("Refused ('0')", "$refusedCount vendors")
-                                            
+
                                             val legitPercentage = if (totalLength > 0) {
-                                                String.format("%.2f%%", (acceptedCount.toDouble() / totalLength) * 100)
+                                                String.format(
+                                                    Locale.getDefault(),
+                                                    "%.2f%%",
+                                                    (acceptedCount.toDouble() / totalLength) * 100
+                                                )
                                             } else "0%"
-                                            DebugInfoItem("Legitimate Interest Rate", "$legitPercentage of possible vendors")
-                                            
-                                            CopyableDebugInfoItem("Full LegitimateInterests String", legitString)
+                                            DebugInfoItem(
+                                                "Legitimate Interest Rate",
+                                                "$legitPercentage of possible vendors"
+                                            )
+
+                                            CopyableDebugInfoItem(
+                                                "Full LegitimateInterests String",
+                                                legitString
+                                            )
                                         }
-                                        
+
                                         // Combined Analysis
                                         if (!vendorConsentsString.isNullOrEmpty() && !vendorLegitimateInterestsString.isNullOrEmpty()) {
                                             Text(
@@ -315,13 +409,21 @@ fun DebugConsentInfoScreen(
                                                 fontWeight = FontWeight.Bold,
                                                 modifier = Modifier.padding(vertical = 8.dp)
                                             )
-                                            
-                                            val consentCount = vendorConsentsString.count { it == '1' }
-                                            val legitCount = vendorLegitimateInterestsString.count { it == '1' }
+
+                                            val consentCount =
+                                                vendorConsentsString.count { it == '1' }
+                                            val legitCount =
+                                                vendorLegitimateInterestsString.count { it == '1' }
                                             val totalAccepted = consentCount + legitCount
-                                            
-                                            DebugInfoItem("Consent + Legit Interest", "$totalAccepted total vendor approvals")
-                                            DebugInfoItem("Breakdown", "$consentCount consent + $legitCount legitimate interest")
+
+                                            DebugInfoItem(
+                                                "Consent + Legit Interest",
+                                                "$totalAccepted total vendor approvals"
+                                            )
+                                            DebugInfoItem(
+                                                "Breakdown",
+                                                "$consentCount consent + $legitCount legitimate interest"
+                                            )
                                         }
                                     }
                                 }
@@ -329,38 +431,44 @@ fun DebugConsentInfoScreen(
                         }
 
                         // Raw Debug Information Section - Show all IABTCF_ fields
-                        debugInfo.consentInfo?.rawDebugInfo?.takeIf { it.isNotEmpty() }?.let { rawInfo ->
-                            item {
-                                ExpandableDebugSection(
-                                    title = "All Raw Debug Fields",
-                                    initiallyExpanded = false
-                                ) {
-                                    // Sort the keys to show IABTCF_ fields first
-                                    val sortedEntries = rawInfo.entries.sortedWith(compareBy { entry ->
-                                        when {
-                                            entry.key.startsWith("IABTCF_") -> "0_${entry.key}"
-                                            else -> "1_${entry.key}"
-                                        }
-                                    })
-                                    
-                                    sortedEntries.forEach { (key, value) ->
-                                        val displayValue = when (value) {
-                                            is String -> if (value.length > 100) {
-                                                "${value.take(50)}...${value.takeLast(20)} (${value.length} chars)"
-                                            } else value
-                                            null -> "null"
-                                            else -> value.toString()
-                                        }
-                                        
-                                        if (value is String && (key.contains("TCString") || key.contains("VendorConsents") || value.length > 50)) {
-                                            CopyableDebugInfoItem(key, value)
-                                        } else {
-                                            DebugInfoItem(key, displayValue)
+                        debugInfo.consentInfo?.rawDebugInfo?.takeIf { it.isNotEmpty() }
+                            ?.let { rawInfo ->
+                                item {
+                                    ExpandableDebugSection(
+                                        title = "All Raw Debug Fields",
+                                        initiallyExpanded = false
+                                    ) {
+                                        // Sort the keys to show IABTCF_ fields first
+                                        val sortedEntries =
+                                            rawInfo.entries.sortedWith(compareBy { entry ->
+                                                when {
+                                                    entry.key.startsWith("IABTCF_") -> "0_${entry.key}"
+                                                    else -> "1_${entry.key}"
+                                                }
+                                            })
+
+                                        sortedEntries.forEach { (key, value) ->
+                                            val displayValue = when (value) {
+                                                is String -> if (value.length > 100) {
+                                                    "${value.take(50)}...${value.takeLast(20)} (${value.length} chars)"
+                                                } else value
+
+                                                null -> "null"
+                                                else -> value.toString()
+                                            }
+
+                                            if (value is String && (key.contains("TCString") || key.contains(
+                                                    "VendorConsents"
+                                                ) || value.length > 50)
+                                            ) {
+                                                CopyableDebugInfoItem(key, value)
+                                            } else {
+                                                DebugInfoItem(key, displayValue)
+                                            }
                                         }
                                     }
                                 }
                             }
-                        }
 
                         // Vendor Information Section
                         debugInfo.vendorInfo?.let { vendorInfo ->
@@ -377,30 +485,55 @@ fun DebugConsentInfoScreen(
                                             fontWeight = FontWeight.Bold,
                                             modifier = Modifier.padding(vertical = 8.dp)
                                         )
-                                        
-                                        DebugInfoItem("Total Vendors (Map)", vendorInfo.totalVendors)
-                                        DebugInfoItem("Consented Vendors", vendorInfo.consentedVendorsCount)
-                                        DebugInfoItem("Refused Vendors", vendorInfo.refusedVendorsCount)
-                                        DebugInfoItem("Calculated Total", "${vendorInfo.calculatedTotal} (${vendorInfo.consentedVendorsCount} + ${vendorInfo.refusedVendorsCount})")
-                                        
+
+                                        DebugInfoItem(
+                                            "Total Vendors (Map)",
+                                            vendorInfo.totalVendors
+                                        )
+                                        DebugInfoItem(
+                                            "Consented Vendors",
+                                            vendorInfo.consentedVendorsCount
+                                        )
+                                        DebugInfoItem(
+                                            "Refused Vendors",
+                                            vendorInfo.refusedVendorsCount
+                                        )
+                                        DebugInfoItem(
+                                            "Calculated Total",
+                                            "${vendorInfo.calculatedTotal} (${vendorInfo.consentedVendorsCount} + ${vendorInfo.refusedVendorsCount})"
+                                        )
+
                                         if (vendorInfo.countDiscrepancy.isNotBlank()) {
-                                            DebugInfoItem("⚠️ Discrepancy", vendorInfo.countDiscrepancy, isError = true)
-                                            val missing = vendorInfo.totalVendors.toIntOrNull()?.let { total ->
-                                                vendorInfo.calculatedTotal.toIntOrNull()?.let { calculated ->
-                                                    total - calculated
+                                            DebugInfoItem(
+                                                "⚠️ Discrepancy",
+                                                vendorInfo.countDiscrepancy,
+                                                isError = true
+                                            )
+                                            val missing = vendorInfo.totalVendors.toIntOrNull()
+                                                ?.let { total ->
+                                                    vendorInfo.calculatedTotal.toIntOrNull()
+                                                        ?.let { calculated ->
+                                                            total - calculated
+                                                        }
                                                 }
-                                            }
                                             if (missing != null && missing != 0) {
-                                                DebugInfoItem("Missing Count", "$missing vendors unaccounted for", isError = true)
+                                                DebugInfoItem(
+                                                    "Missing Count",
+                                                    "$missing vendors unaccounted for",
+                                                    isError = true
+                                                )
                                             }
                                         } else {
-                                            DebugInfoItem("✅ Validation", "All vendors accounted for")
+                                            DebugInfoItem(
+                                                "✅ Validation",
+                                                "All vendors accounted for"
+                                            )
                                         }
-                                        
+
                                         if (!vendorInfo.message.isBlank()) {
                                             DebugInfoItem("Status", vendorInfo.message)
                                         }
-                                        
+
                                         // Vendor ID Lists Section
                                         if (vendorInfo.consentedVendorIds.isNotEmpty() || vendorInfo.refusedVendorIds.isNotEmpty()) {
                                             Text(
@@ -409,16 +542,24 @@ fun DebugConsentInfoScreen(
                                                 fontWeight = FontWeight.Bold,
                                                 modifier = Modifier.padding(vertical = 8.dp)
                                             )
-                                            
+
                                             if (vendorInfo.consentedVendorIds.isNotEmpty()) {
-                                                CopyableDebugInfoItem("Consented IDs (${vendorInfo.consentedVendorIds.size})", vendorInfo.consentedVendorIds.sorted().joinToString(", "))
+                                                CopyableDebugInfoItem(
+                                                    "Consented IDs (${vendorInfo.consentedVendorIds.size})",
+                                                    vendorInfo.consentedVendorIds.sorted()
+                                                        .joinToString(", ")
+                                                )
                                             }
-                                            
+
                                             if (vendorInfo.refusedVendorIds.isNotEmpty()) {
-                                                CopyableDebugInfoItem("Refused IDs (${vendorInfo.refusedVendorIds.size})", vendorInfo.refusedVendorIds.sorted().joinToString(", "))
+                                                CopyableDebugInfoItem(
+                                                    "Refused IDs (${vendorInfo.refusedVendorIds.size})",
+                                                    vendorInfo.refusedVendorIds.sorted()
+                                                        .joinToString(", ")
+                                                )
                                             }
                                         }
-                                        
+
                                         // Individual Vendor Consents (Sample)
                                         if (vendorInfo.vendorConsents.isNotEmpty()) {
                                             Text(
@@ -427,27 +568,42 @@ fun DebugConsentInfoScreen(
                                                 fontWeight = FontWeight.Bold,
                                                 modifier = Modifier.padding(vertical = 8.dp)
                                             )
-                                            
+
                                             // Show first 10 vendors sorted by ID
                                             vendorInfo.vendorConsents.entries
                                                 .sortedBy { it.key.toIntOrNull() ?: Int.MAX_VALUE }
                                                 .take(10)
                                                 .forEach { (vendorId, consent) ->
-                                                    DebugInfoItem("Vendor $vendorId", if (consent == "true") "✅ Consented" else "❌ Refused")
+                                                    DebugInfoItem(
+                                                        "Vendor $vendorId",
+                                                        if (consent == "true") "✅ Consented" else "❌ Refused"
+                                                    )
                                                 }
-                                            
+
                                             if (vendorInfo.vendorConsents.size > 10) {
-                                                DebugInfoItem("...", "And ${vendorInfo.vendorConsents.size - 10} more vendors")
+                                                DebugInfoItem(
+                                                    "...",
+                                                    "And ${vendorInfo.vendorConsents.size - 10} more vendors"
+                                                )
                                             }
                                         } else if (vendorInfo.totalVendors == "0") {
-                                            DebugInfoItem("Note", "No vendor data available yet. Show consent popup first.")
+                                            DebugInfoItem(
+                                                "Note",
+                                                "No vendor data available yet. Show consent popup first."
+                                            )
                                         } else if (vendorInfo.totalVendors != "Error") {
-                                            DebugInfoItem("Vendor Details", "Vendor consent data is being processed...")
+                                            DebugInfoItem(
+                                                "Vendor Details",
+                                                "Vendor consent data is being processed..."
+                                            )
                                         }
                                     } else {
                                         DebugInfoItem("Status", vendorInfo.message)
                                         if (vendorInfo.message.contains("only available for TCF service")) {
-                                            DebugInfoItem("Note", "Switch to Publishers service to access vendor APIs")
+                                            DebugInfoItem(
+                                                "Note",
+                                                "Switch to Publishers service to access vendor APIs"
+                                            )
                                         }
                                     }
                                 }
@@ -483,7 +639,7 @@ private fun ExpandableDebugSection(
     content: @Composable ColumnScope.() -> Unit
 ) {
     var isExpanded by remember { mutableStateOf(initiallyExpanded) }
-    
+
     Card(
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
@@ -506,7 +662,7 @@ private fun ExpandableDebugSection(
                     contentDescription = if (isExpanded) "Collapse" else "Expand"
                 )
             }
-            
+
             AnimatedVisibility(
                 visible = isExpanded,
                 enter = expandVertically(),
@@ -555,7 +711,7 @@ private fun CopyableDebugInfoItem(
     value: String
 ) {
     val clipboardManager = LocalClipboardManager.current
-    
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -579,13 +735,13 @@ private fun CopyableDebugInfoItem(
                 modifier = Modifier.size(24.dp)
             ) {
                 Icon(
-    Icons.Default.Refresh,
+                    Icons.Default.Refresh,
                     contentDescription = "Copy to clipboard",
                     modifier = Modifier.size(16.dp)
                 )
             }
         }
-        
+
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/samplekotlin/src/main/java/io/axept/samplekotlin/screen/DebugConsentInfoViewModel.kt
+++ b/samplekotlin/src/main/java/io/axept/samplekotlin/screen/DebugConsentInfoViewModel.kt
@@ -29,10 +29,11 @@ class DebugConsentInfoViewModel(application: Application) : AndroidViewModel(app
         loadDebugInfo()
     }
 
+    @Suppress("SENSELESS_COMPARISON")
     private fun loadDebugInfo() {
         try {
             val axeptioSDK = AxeptioSDK.instance()
-            
+
             // Collect SDK information
             val sdkInfo = SdkInfo(
                 version = BuildConfig.AXEPTIO_SDK_VERSION,
@@ -54,7 +55,7 @@ class DebugConsentInfoViewModel(application: Application) : AndroidViewModel(app
                 val debugInfo = axeptioSDK.getConsentDebugInfo()
                 val tcfString = debugInfo["IABTCF_TCString"] as? String ?: "No TCF string available"
                 val hasConsent = debugInfo.isNotEmpty()
-                
+
                 ConsentInfo(
                     hasConsent = hasConsent,
                     consentString = tcfString,
@@ -80,13 +81,13 @@ class DebugConsentInfoViewModel(application: Application) : AndroidViewModel(app
                         val vendorConsents = axeptioSDK.getVendorConsents()
                         val consentedVendors = axeptioSDK.getConsentedVendors()
                         val refusedVendors = axeptioSDK.getRefusedVendors()
-                        
+
                         // Calculate detailed breakdown
                         val totalCount = vendorConsents.size
                         val consentedCount = consentedVendors.size
                         val refusedCount = refusedVendors.size
                         val calculatedTotal = consentedCount + refusedCount
-                        
+
                         VendorInfo(
                             isAvailable = true,
                             totalVendors = totalCount.toString(),

--- a/samplekotlin/src/main/java/io/axept/samplekotlin/screen/WebViewScreen.kt
+++ b/samplekotlin/src/main/java/io/axept/samplekotlin/screen/WebViewScreen.kt
@@ -1,7 +1,8 @@
 package io.axept.samplekotlin.screen
 
-import android.net.Uri
+import android.annotation.SuppressLint
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -13,12 +14,12 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.google.accompanist.web.AccompanistWebViewClient
-import com.google.accompanist.web.WebView
-import com.google.accompanist.web.rememberWebViewState
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.net.toUri
 import io.axept.android.library.Axeptio
 import io.axept.android.library.AxeptioSDK
 
+@SuppressLint("SetJavaScriptEnabled")
 @Composable
 internal fun WebViewScreen(
     customToken: String?,
@@ -26,34 +27,38 @@ internal fun WebViewScreen(
     axeptio: Axeptio = AxeptioSDK.instance()
 ) {
     val url = axeptio.appendAxeptioToken(
-        uri = Uri.parse("https://google-cmp-partner.axept.io/cmp-for-publishers.html"),
-        token = customToken ?: axeptio.token ?: ""
-    )
-    val state = rememberWebViewState(url.toString())
+        uri = "https://google-cmp-partner.axept.io/cmp-for-publishers.html".toUri(),
+        token = customToken ?: axeptio.token.orEmpty()
+    ).toString()
 
     Scaffold(
         topBar = {
             TopBar(back = onBack)
         }
     ) { innerPadding ->
-        WebView(
+        AndroidView(
             modifier = Modifier
                 .padding(innerPadding)
                 .fillMaxSize(),
-            state = state,
-            onCreated = {
-                it.settings.javaScriptEnabled = true
-                it.settings.domStorageEnabled = true
-            },
-            client = object : AccompanistWebViewClient() {
-                override fun onPageFinished(view: WebView, url: String?) {
-                    super.onPageFinished(view, url)
-                    view.evaluateJavascript("""localStorage.clear();""".trimIndent(), null)
+            factory = { context ->
+                WebView(context).apply {
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    webViewClient = object : WebViewClient() {
+                        override fun onPageFinished(view: WebView, url: String?) {
+                            super.onPageFinished(view, url)
+                            view.evaluateJavascript("""localStorage.clear();""", null)
+                        }
+                    }
+                    loadUrl(url)
                 }
+            },
+            update = { webView ->
+                // reload if URL changes
+                webView.loadUrl(url)
             }
         )
     }
-
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/samplekotlin/src/main/java/io/axept/samplekotlin/screen/WebViewScreen.kt
+++ b/samplekotlin/src/main/java/io/axept/samplekotlin/screen/WebViewScreen.kt
@@ -1,6 +1,9 @@
 package io.axept.samplekotlin.screen
 
 import android.annotation.SuppressLint
+import android.util.Log
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,7 +16,11 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
 import io.axept.android.library.Axeptio
@@ -26,36 +33,43 @@ internal fun WebViewScreen(
     onBack: () -> Unit,
     axeptio: Axeptio = AxeptioSDK.instance()
 ) {
-    val url = axeptio.appendAxeptioToken(
-        uri = "https://google-cmp-partner.axept.io/cmp-for-publishers.html".toUri(),
-        token = customToken ?: axeptio.token.orEmpty()
-    ).toString()
+    val context = LocalContext.current
+
+    val url by remember(customToken, axeptio.token) {
+        mutableStateOf(
+            axeptio.appendAxeptioToken(
+                uri = "https://google-cmp-partner.axept.io/cmp-for-publishers.html".toUri(),
+                token = customToken ?: axeptio.token.orEmpty()
+            ).toString()
+        )
+    }
+
+    val webView = remember {
+        WebView(context).apply {
+            settings.apply {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+            }
+
+            webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView, url: String?) {
+                    super.onPageFinished(view, url)
+                    view.evaluateJavascript("localStorage.clear();", null)
+                }
+            }
+        }
+    }
 
     Scaffold(
-        topBar = {
-            TopBar(back = onBack)
-        }
+        topBar = { TopBar(back = onBack) }
     ) { innerPadding ->
         AndroidView(
             modifier = Modifier
                 .padding(innerPadding)
                 .fillMaxSize(),
-            factory = { context ->
-                WebView(context).apply {
-                    settings.javaScriptEnabled = true
-                    settings.domStorageEnabled = true
-                    webViewClient = object : WebViewClient() {
-                        override fun onPageFinished(view: WebView, url: String?) {
-                            super.onPageFinished(view, url)
-                            view.evaluateJavascript("""localStorage.clear();""", null)
-                        }
-                    }
-                    loadUrl(url)
-                }
-            },
+            factory = { webView },
             update = { webView ->
-                // reload if URL changes
-                webView.loadUrl(url)
+                if(webView.url != url) webView.loadUrl(url)
             }
         )
     }
@@ -65,10 +79,13 @@ internal fun WebViewScreen(
 @Composable
 private fun TopBar(back: () -> Unit) {
     TopAppBar(
-        title = { },
+        title = {},
         navigationIcon = {
             IconButton(onClick = back) {
-                Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "back")
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "back"
+                )
             }
         }
     )

--- a/samplekotlin/src/main/java/io/axept/samplekotlin/ui/theme/Theme.kt
+++ b/samplekotlin/src/main/java/io/axept/samplekotlin/ui/theme/Theme.kt
@@ -1,6 +1,9 @@
 package io.axept.samplekotlin.ui.theme
 
 import android.app.Activity
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -32,19 +35,33 @@ private val LightColorScheme = lightColorScheme(
 
 @Composable
 fun SampleKotlinTheme(
-    // Dynamic color is available on Android 12+
     content: @Composable () -> Unit
 ) {
-    val colorScheme =  LightColorScheme
-
+    val colorScheme = LightColorScheme
     val view = LocalView.current
+
     if (!view.isInEditMode) {
         SideEffect {
-            val window = (view.context as Activity).window
-            WindowCompat.setDecorFitsSystemWindows(window, false)
-            WindowInsetsControllerCompat(window, window.decorView)
-                .isAppearanceLightStatusBars = true
+            val activity = view.context as ComponentActivity
+            val window = activity.window
+
+            activity.enableEdgeToEdge(
+                statusBarStyle = SystemBarStyle.light(
+                    scrim = colorScheme.primary.toArgb(),
+                    darkScrim = colorScheme.primary.toArgb()
+                ),
+                navigationBarStyle = SystemBarStyle.light(
+                    scrim = colorScheme.background.toArgb(),
+                    darkScrim = colorScheme.background.toArgb()
+                )
+            )
+
+            // Use SystemBarStyle to color the status bar
+            WindowCompat.setDecorFitsSystemWindows(window, true)
+            WindowCompat.getInsetsController(window, window.decorView).systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         }
+
     }
 
     MaterialTheme(

--- a/samplekotlin/src/main/java/io/axept/samplekotlin/ui/theme/Theme.kt
+++ b/samplekotlin/src/main/java/io/axept/samplekotlin/ui/theme/Theme.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
 
 
 private val LightColorScheme = lightColorScheme(
@@ -40,8 +41,9 @@ fun SampleKotlinTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+            WindowInsetsControllerCompat(window, window.decorView)
+                .isAppearanceLightStatusBars = true
         }
     }
 


### PR DESCRIPTION
## Description

This PR addresses multiple deprecated API warnings in the Android sample app to maintain code quality and future compatibility.  

### Issues Resolved

**Java Deprecated APIs (samplejava)**
- `SharedPreferencesRepository.java` uses or overrides a deprecated API.  
- `MainViewModel.java` uses unchecked or unsafe operations.  

**Kotlin Deprecated APIs (samplekotlin)**

1. **Material Design Icons**  
   - `ArrowBack: ImageVector` is deprecated.  
   - ✅ Replaced with `Icons.AutoMirrored.Filled.ArrowBack`.  
   - File: `DebugConsentInfoScreen.kt:52:44`.  

2. **Accompanist WebView (CRITICAL - Library Deprecated)**  
   - `AccompanistWebViewClient` is deprecated.  
   - `accompanist/web` is no longer maintained.  
   - ℹ️ Recommendation: Fork and customise if long-term support is required.  
   - Files: `WebViewScreen.kt` (multiple usages).  
   - **Impact:** Entire WebView functionality requires migration.  

3. **Android System UI**  
   - Setter for `statusBarColor: Int` is deprecated in Java.  
   - File: `Theme.kt:43:20`.  

4. **Code Quality Issues**  
   - Unused variable: `context` (DebugConsentInfoScreen.kt:537:9).  
   - Always true condition: `axeptioSDK != null` (DebugConsentInfoViewModel.kt:42:33).  

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes deprecated API warnings across the Android sample app and migrates off Accompanist WebView. Reduces CI noise and aligns the sample with current Android/Compose APIs. Addresses Linear MSK-86.

- **Bug Fixes**
  - Migrated WebView from Accompanist to native WebView (AndroidView + WebViewClient), enabled JS/DOM storage, and cleared localStorage on page finish.
  - Replaced deprecated ArrowBack icon with Icons.AutoMirrored.Filled.ArrowBack.
  - Replaced deprecated status bar API with WindowCompat.setDecorFitsSystemWindows and WindowInsetsControllerCompat.
  - Removed unused variables and suppressed a senseless comparison warning in DebugConsentInfoViewModel.
  - Replaced deprecated PreferenceManager.getDefaultSharedPreferences with application.getSharedPreferences in samplejava.
  - Hardened ViewModel Factory with type check and @SuppressWarnings("unchecked"); removed unused imports.
  - Fixed build config: set versionCode = 1 for both sample modules.

<!-- End of auto-generated description by cubic. -->

