### PR TITLE
docs: announce 2.2.0-beta.1 sample-app branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # Axeptio Android SDK Documentation
 
+> **🚧 `2.2.0-beta.1` is available.** A beta of this sample app aligned with Axeptio Android SDK `2.2.0-beta.1` is on the [`release/2.2.0-beta.1`](https://github.com/axeptio/sample-app-android/tree/release/2.2.0-beta.1) branch. It drops the `samplejava/` module (the SDK dropped Java support), showcases the new `AxeptioStore` Compose API, and exercises `setForceShowConsentDebug()`. Stable integrators should stay on `master`.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/axeptio/sample-app-android/pulls)  [![Axeptio SDK Version](https://img.shields.io/github/v/release/axeptio/axeptio-android-sdk)](https://github.com/axeptio/axeptio-android-sdk/releases) [![Java Integration](https://img.shields.io/badge/Integration-Java%20%26%20XML-blue)](https://github.com/axeptio/sample-app-android/tree/main/samplejava) [![Kotlin Integration](https://img.shields.io/badge/Integration-Kotlin%20%26%20Compose-blue)](https://github.com/axeptio/sample-app-android/tree/main/samplekotlin) [![Android SDK Compatibility](https://img.shields.io/badge/Android%20SDK-%3E%3D%2026-blue)](https://developer.android.com/studio)
  


### PR DESCRIPTION
## Summary
Adds a beta notice banner at the top of the README pointing integrators at [`release/2.2.0-beta.1`](https://github.com/axeptio/sample-app-android/tree/release/2.2.0-beta.1), which aligns the public sample with Axeptio Android SDK `2.2.0-beta.1`.

Mirrors the equivalent iOS change (commit `cba7371` on `sample-app-ios`) so the two mobile sample repos tell customers the same story:
- Drops the `samplejava/` module (the SDK dropped Java language support)
- Showcases the new `AxeptioStore` StateFlow Compose API
- Exercises `setForceShowConsentDebug()` and the new `onError` listener callback

Stable integrators should stay on `master`.

## Test plan
- [ ] README renders the banner above the "Axeptio Android SDK Documentation" intro on the rendered page
- [ ] The `Validate PR Title / Normalize and validate PR title` required status check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)